### PR TITLE
prefer fzf over files and gof

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Or type `,f`
 
 ## Requirements
 
-* [files](https://github.com/mattn/files)
-* [gof](https://github.com/mattn/gof)
+* [fzf](https://github.com/junegunn/fzf) or [files](https://github.com/mattn/files) and [gof](https://github.com/mattn/gof)
 * vim8
 
 ## Installation

--- a/plugin/fz.vim
+++ b/plugin/fz.vim
@@ -27,7 +27,12 @@ function! s:quote(arg)
   return "'" . substitute(a:arg, "'", "\\'", 'g') . "'"
 endfunction
 
-let s:fz_command = get(g:, 'fz_command', 'files -I FZ_IGNORE -A | gof')
+if executable('fzf')
+    let s:fz_command = get(g:, 'fz_command', 'fzf')
+else
+    let s:fz_command = get(g:, 'fz_command', 'files -I FZ_IGNORE -A | gof')
+endif
+
 function! s:fz()
   if !has('patch-8.0.928')
     echohl ErrorMsg | echo "vim-fz doesn't work on legacy vim" | echohl None


### PR DESCRIPTION
I have a large code base where searching with `files` and `gof` doesn't seem to be responsive as searching with `fzf`. I noticed that the problem isn't with `vim-fz` but rather with `files` and `gof`. Easy way to reproduce this would be to go to `c:\windows` directory and try `files -A | gof` and `fzf` and search for `etc/hosts`.