### PR TITLE
add support for neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vim-fz
 
-Ultra Fast Fuzzy finder for Vim8.
+Ultra Fast Fuzzy finder for Vim8 and NeoVim.
 
 But very very experimental!
 
@@ -18,7 +18,7 @@ Or type `,f`
 
 * [files](https://github.com/mattn/files)
 * [gof](https://github.com/mattn/gof)
-* vim8
+* vim8 or neovim
 
 ## Installation
 


### PR DESCRIPTION
This makes `vim-fz` work in both vim8 and neovim.

Apparently for some reason running `gof` in bash on windows (archlinux) didn't work, but setting `s:fz_command` to `fzf` seems to work.

I can verify this on my mac later.