### PR TITLE
use { 'items': [...] } instead of files for accept callback

### DIFF
--- a/autoload/fz.vim
+++ b/autoload/fz.vim
@@ -16,7 +16,7 @@ function! s:exit_cb(job, st, ...) " neovim passes third argument as 'exit' while
     return
   endif
   if has_key(s:ctx, 'accept')
-    call call(s:ctx['accept'], files)
+    call call(s:ctx['accept'], { 'items': files })
   else
     if len(files) == 1
       exe 'edit' files[0]


### PR DESCRIPTION
This is primarily so that in the future if we add 'ctrl+t', 'ctrl+v', 'ctrl+s' or any other support it will allow us to modify without breaking people. Also changed it to `items` since it can be used to pick anything besides files.