### PR TITLE
use type({}) instead of 4

### DIFF
--- a/autoload/fz.vim
+++ b/autoload/fz.vim
@@ -43,7 +43,7 @@ function! fz#run(...)
     return
   endif
   let s:ctx = get(a:000, 0, {})
-  if type(s:ctx) != 4
+  if type(s:ctx) != type({})
     echohl ErrorMsg | echo "invalid argument" | echohl None
     return
   endif


### PR DESCRIPTION
Hopefully this would make it easier to follow the code. Given that we already have a check for vim version we can guarantee that `type()` already exists.