### PR TITLE
separate s:fz_command to g:fz_command and g:fz_command_files

### DIFF
--- a/autoload/fz.vim
+++ b/autoload/fz.vim
@@ -37,8 +37,6 @@ function! s:quote(arg)
   return "'" . substitute(a:arg, "'", "\\'", 'g') . "'"
 endfunction
 
-let s:fz_command = get(g:, 'fz_command', 'files -I FZ_IGNORE -A | gof')
-
 function! fz#run(...)
   if !s:is_nvim && !has('patch-8.0.928')
     echohl ErrorMsg | echo "vim-fz doesn't work on legacy vim" | echohl None
@@ -54,7 +52,7 @@ function! fz#run(...)
   let typ = get(ctx['options'], 'type', 'cmd')
   if typ == 'cmd'
     let $FZ_IGNORE = get(ctx['options'], 'ignore', '(^|[\/])(\.git|\.hg|\.svn|\.settings|\.gitkeep|target|bin|node_modules|\.idea|^vendor)$|\.(exe|so|dll|png|obj|o|idb|pdb)$')
-    let fzcmd = get(ctx['options'], 'cmd', s:fz_command)
+    let fzcmd = get(ctx['options'], 'cmd', empty(g:fz_command_files) ? g:fz_command : printf('%s | %s', g:fz_command_files, g:fz_command))
   else
     echohl ErrorMsg | echo "unsupported type" | echohl None
     return

--- a/plugin/fz.vim
+++ b/plugin/fz.vim
@@ -1,3 +1,11 @@
+if exists('g:fz_loaded')
+  finish
+endif
+let g:fz_loaded = 1
+
+let g:fz_command = get(g:, 'fz_command', 'gof')
+let g:fz_command_files = get(g:, 'fz_command_files', 'files -I FZ_IGNORE -A')
+
 command! Fz call fz#run()
 nnoremap <Plug>(fz) :<c-u>Fz<cr>
 if !hasmapto('<Plug>(fz)')


### PR DESCRIPTION
This allows me to do this.

```vim
call fz#run({ 'type': 'cmd', 'cmd': 'git ls-files \| ' . g:fz_command })
```

instead of

```vim
call fz#run({ 'type': 'cmd', 'cmd': 'git ls-files \| gof' })
" or
call fz#run({ 'type': 'cmd', 'cmd': 'git ls-files \| fzf' })
```

Now to configure `fzf` one would need to make sure to set both variables.

```
let g:fz_command = 'fzf'
let g:fz_command_files = ''
```