### PR TITLE
support type: 'file' 

### DIFF
--- a/autoload/fz.vim
+++ b/autoload/fz.vim
@@ -37,8 +37,6 @@ function! s:quote(arg)
   return "'" . substitute(a:arg, "'", "\\'", 'g') . "'"
 endfunction
 
-let s:fz_command = get(g:, 'fz_command', 'files -I FZ_IGNORE -A | gof')
-
 function! fz#run(...)
   if !s:is_nvim && !has('patch-8.0.928')
     echohl ErrorMsg | echo "vim-fz doesn't work on legacy vim" | echohl None
@@ -54,7 +52,7 @@ function! fz#run(...)
   let typ = get(ctx['options'], 'type', 'cmd')
   if typ == 'cmd'
     let $FZ_IGNORE = get(ctx['options'], 'ignore', '(^|[\/])(\.git|\.hg|\.svn|\.settings|\.gitkeep|target|bin|node_modules|\.idea|^vendor)$|\.(exe|so|dll|png|obj|o|idb|pdb)$')
-    let fzcmd = get(ctx['options'], 'cmd', s:fz_command)
+    let fzcmd = get(ctx['options'], 'cmd', empty(g:fz_command_files) ? g:fz_command : printf('%s | %s', g:fz_command_files, g:fz_command))
   else
     echohl ErrorMsg | echo "unsupported type" | echohl None
     return

--- a/plugin/fz.vim
+++ b/plugin/fz.vim
@@ -1,3 +1,11 @@
+if exists('g:fz_loaded')
+  finish
+endif
+let g:fz_loaded = 1
+
+let g:fz_command = get(g:, 'fz_command', 'gof')
+let g:fz_command_files = get(g:, 'fz_command_files', 'files -I FZ_IGNORE -A')
+
 command! Fz call fz#run()
 nnoremap <Plug>(fz) :<c-u>Fz<cr>
 if !hasmapto('<Plug>(fz)')


### PR DESCRIPTION
This commit depends on https://github.com/mattn/vim-fz/pull/9 which is already included on this PR. But let us try to lock down on #9 before we merge this in.
    
    add support for type == 'file'
    
    * fix s:quote() so it converts / to \ on windows
      some windows commands such as type, dir treats / as start of params,
      so when shellslash is enabled it would break
    * uses 'type' on windows and 'cat' on *nix systems.
    
    usage:
      " by default this would pipe to g:fz_command
      call fz#run({ 'type': 'file', 'file': expand('~/somefile') })
    
      " if you would like to override g:fz_command just for this function, pass 'fz_command' option
      call fz#run({ 'type': 'file', 'file': expand('~/somefile'), 'fz_command': 'fzf' })
    
      " if you want to use your own tool instead of pipe use type=='cmd' instead
      call fz#run({ 'type': 'cmd', 'cmd': 'mytool ~/somefile' })

This would also act as a foundation for `type: 'list'` because I can save the list into a file and internally use this method.