### PR TITLE
add support for actions

### DIFF
--- a/plugin/fz.vim
+++ b/plugin/fz.vim
@@ -5,6 +5,12 @@ let g:fz_loaded = 1
 
 let g:fz_command = get(g:, 'fz_command', 'gof')
 let g:fz_command_files = get(g:, 'fz_command_files', 'files -I FZ_IGNORE -A')
+let g:fz_command_options_action = get(g:, 'fz_command_options_action', '-a=%s')
+let g:fz_command_actions = {
+  \ 'ctrl-t': 'tab split',
+  \ 'ctrl-x': 'split',
+  \ 'ctrl-v': 'vsplit'
+  \ }
 
 command! Fz call fz#run()
 nnoremap <Plug>(fz) :<c-u>Fz<cr>


### PR DESCRIPTION
Added support for actions. 

* `ctrl-t` to open in new tab
* `ctrl-v` to open in vsplit
* `ctrl-x` top open in split.

Use `g:fz_command_actions` to modify the default.

Here is another example of using custom actions for custom functions.


```vim
function! s:accept_gfiles(result)
    if a:result['action'] == 'reset'
        for item in a:result['items']
            call system('git reset ' . a:result['items'][0])
        endfor
    else
        exe 'edit' a:result['items'][0]
    endif
endfunction

command! FzGFiles call fz#run({
    \ 'type': 'cmd',
    \ 'cmd': 'git ls-files',
    \ 'accept': function('s:accept_gfiles'),
    \ 'actions': {
    \   'ctrl-x': 'reset',
    \ },
    \ })
```

This PR contains breaking change. Instead of using `cmd: 'git ls-files | ' . g:fz_command`  you now need to pass two different options. `cmd: 'git ls-files'` and `fz_command: 'gof'`. If `cmd` isn't passed it uses `g:fz_command_files`.