### PR TITLE
Fix enable ctrl-o

### DIFF
--- a/plugin/fz.vim
+++ b/plugin/fz.vim
@@ -7,6 +7,7 @@ let g:fz_command = get(g:, 'fz_command', 'gof')
 let g:fz_command_files = get(g:, 'fz_command_files', 'files -I FZ_IGNORE -A')
 let g:fz_command_options_action = get(g:, 'fz_command_options_action', '-a=%s')
 let g:fz_command_actions = {
+  \ 'ctrl-o': 'edit',
   \ 'ctrl-t': 'tab split',
   \ 'ctrl-x': 'split',
   \ 'ctrl-v': 'vsplit'


### PR DESCRIPTION
Ctrl-o displays followings messages.

```
Vim: Warning: Output is not to a terminal
Vim: Warning: Input is not from a terminal
```

Add ctrl-o mapping to edit as default.

Please review this ☺️ 