### PR TITLE
Add base path for enable start Fz with specific path

### DIFF
--- a/autoload/fz.vim
+++ b/autoload/fz.vim
@@ -107,7 +107,8 @@ function! fz#run(...)
     return
   endif
 
-  let basepath = get(a:000, 1, '')
+  " Get basepath
+  let basepath = get(ctx['options'], 'basepath', '')
   if basepath != ''
     let basepath = expand(basepath)
   endif

--- a/autoload/fz.vim
+++ b/autoload/fz.vim
@@ -107,12 +107,18 @@ function! fz#run(...)
     return
   endif
 
+  let basepath = get(a:000, 1, '')
+  if basepath != ''
+    let basepath = expand(basepath)
+  endif
+
   " check type
   let typ = get(ctx['options'], 'type', 'cmd')
   if typ == 'cmd'
     let $FZ_IGNORE = get(ctx['options'], 'ignore', '(^|[\/])(\.git|\.hg|\.svn|\.settings|\.gitkeep|target|bin|node_modules|\.idea|^vendor)$|\.(exe|so|dll|png|obj|o|idb|pdb)$')
     let fz_command = get(ctx['options'], 'fz_command', g:fz_command)
     let cmd = get(ctx['options'], 'cmd', g:fz_command_files)
+    let cmd = isdirectory(basepath) ? printf(cmd, basepath) : printf(cmd, '')
     let fzcmd = empty(cmd) ? printf('%s%s', g:fz_command, s:get_fzcmd_options(ctx)) : printf('%s | %s%s', cmd, fz_command, s:get_fzcmd_options(ctx))
   elseif typ == 'file'
     if !has_key(ctx['options'], 'file')

--- a/autoload/fz.vim
+++ b/autoload/fz.vim
@@ -108,10 +108,7 @@ function! fz#run(...)
   endif
 
   " Get basepath
-  let basepath = get(ctx['options'], 'basepath', '')
-  if basepath != ''
-    let basepath = expand(basepath)
-  endif
+  let basepath = expand(get(ctx['options'], 'basepath', '.'))
 
   " check type
   let typ = get(ctx['options'], 'type', 'cmd')
@@ -119,7 +116,7 @@ function! fz#run(...)
     let $FZ_IGNORE = get(ctx['options'], 'ignore', '(^|[\/])(\.git|\.hg|\.svn|\.settings|\.gitkeep|target|bin|node_modules|\.idea|^vendor)$|\.(exe|so|dll|png|obj|o|idb|pdb)$')
     let fz_command = get(ctx['options'], 'fz_command', g:fz_command)
     let cmd = get(ctx['options'], 'cmd', g:fz_command_files)
-    let cmd = isdirectory(basepath) ? printf(cmd, basepath) : printf(cmd, '')
+    let cmd = printf(cmd, basepath)
     let fzcmd = empty(cmd) ? printf('%s%s', g:fz_command, s:get_fzcmd_options(ctx)) : printf('%s | %s%s', cmd, fz_command, s:get_fzcmd_options(ctx))
   elseif typ == 'file'
     if !has_key(ctx['options'], 'file')

--- a/plugin/fz.vim
+++ b/plugin/fz.vim
@@ -13,7 +13,7 @@ let g:fz_command_actions = {
   \ 'ctrl-v': 'vsplit'
   \ }
 
-command! -nargs=* -complete=dir Fz call fz#run({}, <q-args>)
+command! -nargs=* -complete=dir Fz call fz#run({'basepath': <q-args>})
 nnoremap <Plug>(fz) :<c-u>Fz<cr>
 if !hasmapto('<Plug>(fz)')
   nmap ,f <Plug>(fz)

--- a/plugin/fz.vim
+++ b/plugin/fz.vim
@@ -4,7 +4,7 @@ endif
 let g:fz_loaded = 1
 
 let g:fz_command = get(g:, 'fz_command', 'gof')
-let g:fz_command_files = get(g:, 'fz_command_files', 'files -I FZ_IGNORE -A')
+let g:fz_command_files = get(g:, 'fz_command_files', 'files %s -I FZ_IGNORE -A')
 let g:fz_command_options_action = get(g:, 'fz_command_options_action', '-a=%s')
 let g:fz_command_actions = {
   \ 'ctrl-o': 'edit',
@@ -13,7 +13,7 @@ let g:fz_command_actions = {
   \ 'ctrl-v': 'vsplit'
   \ }
 
-command! Fz call fz#run()
+command! -nargs=* -complete=dir Fz call fz#run({}, <q-args>)
 nnoremap <Plug>(fz) :<c-u>Fz<cr>
 if !hasmapto('<Plug>(fz)')
   nmap ,f <Plug>(fz)


### PR DESCRIPTION
Add root path option.
```
:Fz ~/.vim/pack/bundle/start
```
![vim-fz](https://user-images.githubusercontent.com/56591/31447461-fd89abbc-aedc-11e7-9a24-c3936399dfc7.gif)
