### PR TITLE
Fix fzf not working

### DIFF
--- a/autoload/fz.vim
+++ b/autoload/fz.vim
@@ -84,6 +84,9 @@ function! s:get_fzcmd_options(ctx)
   let actions = get(a:ctx['options'], 'actions', g:fz_command_actions)
   if !empty(actions)
     let options_action = get(a:ctx['options'], 'options_action', g:fz_command_options_action)
+    if options_action == ''
+      return ''
+    endif
     let a:ctx['actions'] = actions
     return ' ' . printf(options_action, join(keys(actions), ','))
   endif


### PR DESCRIPTION
Currently `fzf` is not working.

```viml
let g:fz_command = expand('~/.fzf/bin/fzf')
let g:fz_command_files = ''
```
Does not show fzf.

When set `let g:fz_command_options_action = ''` following error raised and start fzf.

`E767: Too many arguments to printf()`

Fix if `g:fz_command_options_action` is empty string.