### PR TITLE
fix when g:fz_command_files is empty or doesn't contains placeholder for basepath

### DIFF
--- a/autoload/fz.vim
+++ b/autoload/fz.vim
@@ -119,7 +119,7 @@ function! fz#run(...)
     let $FZ_IGNORE = get(ctx['options'], 'ignore', '(^|[\/])(\.git|\.hg|\.svn|\.settings|\.gitkeep|target|bin|node_modules|\.idea|^vendor)$|\.(exe|so|dll|png|obj|o|idb|pdb)$')
     let fz_command = get(ctx['options'], 'fz_command', g:fz_command)
     let cmd = get(ctx['options'], 'cmd', g:fz_command_files)
-    if !empty(cmd)
+    if match(cmd, '%s') > -1
         let cmd = printf(cmd, basepath)
     endif
     let fzcmd = empty(cmd) ? printf('%s%s', g:fz_command, s:get_fzcmd_options(ctx)) : printf('%s | %s%s', cmd, fz_command, s:get_fzcmd_options(ctx))

--- a/autoload/fz.vim
+++ b/autoload/fz.vim
@@ -119,7 +119,9 @@ function! fz#run(...)
     let $FZ_IGNORE = get(ctx['options'], 'ignore', '(^|[\/])(\.git|\.hg|\.svn|\.settings|\.gitkeep|target|bin|node_modules|\.idea|^vendor)$|\.(exe|so|dll|png|obj|o|idb|pdb)$')
     let fz_command = get(ctx['options'], 'fz_command', g:fz_command)
     let cmd = get(ctx['options'], 'cmd', g:fz_command_files)
-    let cmd = printf(cmd, basepath)
+    if !empty(cmd)
+        let cmd = printf(cmd, basepath)
+    endif
     let fzcmd = empty(cmd) ? printf('%s%s', g:fz_command, s:get_fzcmd_options(ctx)) : printf('%s | %s%s', cmd, fz_command, s:get_fzcmd_options(ctx))
   elseif typ == 'file'
     if !has_key(ctx['options'], 'file')


### PR DESCRIPTION
This makes it work when `g:fz_command_files` is empty.

```vim
let g:fz_command = 'fzf'
let g:fz_command_files = ''
let g:fz_command_options_action = ''
```

Ideally we should have something like `g:fz_command_options_path` so that we can append it in `g:fz_command` like how we append `g:fz_command_options_action`. But I didn't see fzf implementing it so didn't implement it here. This means `:Fz dir` will work as `:Fz` for now, if others want to support directory they still have to set `g:fz_command_files`.

This is lot better then seeing this error.

![image](https://user-images.githubusercontent.com/287744/38166885-0e8e9ccc-34e0-11e8-89d2-49cebbcb58d7.png)
