### PR TITLE
add support for ripgrep columns

### DIFF
--- a/autoload/fz.vim
+++ b/autoload/fz.vim
@@ -57,10 +57,21 @@ function! s:exit_cb(ctx, job, st, ...) abort
     endif
 
     if len(l:items) ==# 1 && l:action ==# ''
-      let l:path = expand(l:items[0])
+
+	  if get(a:ctx['options'], 'output', '') ==# 'rgcolumn'
+        let l:parts = matchlist(l:items[0], '\(.\{-}\):\(\d\+\)\%(:\(\d\+\)\)\?\%(:\(.*\)\)\?')
+        let l:path = &acd ? fnamemodify(l:parts[1], ':p') : l:parts[1]
+		let l:path = expand(l:path)
+        let l:lnum = l:parts[2]
+        let l:col = l:parts[3]
+      else
+		  let l:path = expand(l:items[0])
+	  endif
+
       if !s:absolute_path(l:path)
         let l:path = a:ctx.basepath . '/' . l:path
       endif
+
       if filereadable(expand(l:path))
         if &modified
           if winwidth(win_getid()) > winheight(win_getid()) * 3
@@ -70,6 +81,11 @@ function! s:exit_cb(ctx, job, st, ...) abort
           endif
         else
           exe 'edit' l:path
+        endif
+        if exists('l:lnum') | execute l:lnum | endif
+        if exists('l:col') | execute 'normal!' l:col . '|' | endif
+        if exists('l:lnum') || exists('l:col')
+          normal! zz
         endif
       endif
     else


### PR DESCRIPTION
This adds support for handling `ripgrep` columns and then type `:Rg searchterm` then press enter and use `gof` to fuzzy search the results of ripgrep.

In your `.vimrc` add the following.

```vim
noremap <leader>s :Rg 
command! -bang -nargs=* Rg
  \ call fz#run({
  \   'type': 'cmd',
  \   'output': 'rgcolumn',
  \   'cmd': 'rg --column --line-number --no-heading --color=auto '.shellescape(<q-args>),
  \ })
```

This introduces `output: 'rgcolumn'` which parses the line as ripgrep column splits it and open in exact linenumber and column and then centers the search result. (Also might be a bug in `gof` where `\t` is not getting rendered as proper tabs. In fzf I see good amount of spacing in output similar to this terminal output.)

```
$ rg --column --line-number --no-heading --color=auto 'github' | gof
templates/base.rs.html:41:17:                   @if let Some(github) = blog.get_blog_conf().get_github() {
```

Demo (https://asciinema.org/a/341801)
![vim-fz-ripgrep](https://user-images.githubusercontent.com/287744/85256554-48654580-b419-11ea-8fb0-e33e08e9b21f.gif)

Given that `ripgrep` is so popular might be even good to add this as default in vimfz as `FzRg`. Thoughts?

This same can be accomplished in `fzf.vim` via the following: This PR is mostly ported from `fzf.vim`.

```vim
noremap <leader>s :Rg 

let g:fzf_layout = { 'down': '~40%' }
command! -bang -nargs=* Rg
  \ call fzf#vim#grep(
  \   'rg --column --line-number --no-heading --color=always '.shellescape(<q-args>), 1,
  \   <bang>0 ? fzf#vim#with_preview('up:60%')
  \           : fzf#vim#with_preview('right:50%:hidden', '?'),
  \   <bang>0)
```