### PR TITLE
add support for options.message

### DIFF
--- a/autoload/fz.vim
+++ b/autoload/fz.vim
@@ -178,4 +178,7 @@ function! fz#run(...)
   else
     call term_start(l:cmd, {'term_name': 'Fz', 'curwin': l:ctx['buf'], 'exit_cb': function('s:exit_cb', [l:ctx]), 'tty_type': 'conpty', 'cwd': l:ctx['basepath']})
   endif
+  if has_key(l:ctx['options'], 'message')
+    echo l:ctx['options']['message']
+  endif
 endfunction


### PR DESCRIPTION

```vim
nnoremap <C-p> :execute system('git rev-parse --is-inside-work-tree') =~ 'true'
      \ ? fz#run({ 'type': 'cmd', 'cmd': 'git ls-files', 'message': 'Fz: git ls-files' })
      \ : 'Fz'<CR>
```

Before:
![image](https://user-images.githubusercontent.com/287744/92318979-68dc7f00-efc8-11ea-8687-e99c9baa53ca.png)

After with message set:
![image](https://user-images.githubusercontent.com/287744/92318964-421e4880-efc8-11ea-98bc-108f47836b6b.png)



